### PR TITLE
[AudioTrack] 해당 가이드의 오디오 트랙 정보 리스트 API

### DIFF
--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideController.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +18,9 @@ import team_mic.here_and_there.backend.audio_guide.domain.repository.AudioGuideR
 import team_mic.here_and_there.backend.audio_guide.domain.repository.AudioGuideTrackContainerRepository;
 import team_mic.here_and_there.backend.audio_guide.domain.repository.AudioTrackRepository;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioGuideListDto;
+import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioTrackInfoListDto;
 import team_mic.here_and_there.backend.audio_guide.service.AudioGuideService;
+import team_mic.here_and_there.backend.audio_guide.service.AudioTrackService;
 import team_mic.here_and_there.backend.location_tag.domain.entity.AudioGuideTag;
 import team_mic.here_and_there.backend.location_tag.domain.entity.Tag;
 import team_mic.here_and_there.backend.location_tag.domain.repository.AudioGuideTagRepository;
@@ -32,6 +35,7 @@ import java.util.Set;
 public class AudioGuideController {
 
   private final AudioGuideService audioGuideService;
+  private final AudioTrackService audioTrackService;
 
   private final AudioGuideRepository audioGuideRepository;
   private final AudioTrackRepository audioTrackRepository;
@@ -60,6 +64,13 @@ public class AudioGuideController {
     }
 
     return ResponseEntity.status(HttpStatus.OK).body(audioGuideService.getAudioGuideList(category));
+  }
+
+  @GetMapping("/audio-guides/{audio-guide-id:^[0-9]+$}/audio-tracks")
+  public ResponseEntity<ResAudioTrackInfoListDto> getAudioGuidesTrackList(
+      @PathVariable("audio-guide-id") Long audioGuideId) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(audioTrackService.getAudioGuidesTrackList(audioGuideId));
   }
 
   @ApiIgnore

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideController.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideController.java
@@ -73,6 +73,55 @@ public class AudioGuideController {
         .body(audioTrackService.getAudioGuidesTrackList(audioGuideId));
   }
 
+  @PostMapping("/audio-guides/audio-tracks/dump")
+  public ResponseEntity<Void> addDumpTracks(){
+    AudioGuide audioGuide = audioGuideRepository.save(AudioGuide.builder().title("test").build());
+    AudioTrack audioTrack1 = audioTrackRepository.save(AudioTrack.builder()
+    .audioFileUrl("track1.file")
+    .title("트랙1")
+    .image("트랙1 이미지").build());
+    AudioTrack audioTrack2 = audioTrackRepository.save(AudioTrack.builder()
+        .audioFileUrl("track2.file")
+        .title("트랙2")
+        .image("트랙2 이미지").build());
+    AudioTrack audioTrack3 = audioTrackRepository.save(AudioTrack.builder()
+        .audioFileUrl("track3.file")
+        .title("트랙3")
+        .image("트랙3 이미지").build());
+
+    audioGuideTrackContainerRepository.save(AudioGuideTrackContainer.builder()
+    .audioGuide(audioGuide)
+    .audioTrack(audioTrack3)
+    .orderNumber(3).build());
+    audioGuideTrackContainerRepository.save(AudioGuideTrackContainer.builder()
+        .audioGuide(audioGuide)
+        .audioTrack(audioTrack2)
+        .orderNumber(2).build());
+    audioGuideTrackContainerRepository.save(AudioGuideTrackContainer.builder()
+        .audioGuide(audioGuide)
+        .audioTrack(audioTrack1)
+        .orderNumber(1).build());
+
+    AudioGuide audioGuide2 = audioGuideRepository.save(AudioGuide.builder().title("test2").build());
+    AudioTrack audioTrack2_1 = audioTrackRepository.save(AudioTrack.builder()
+        .audioFileUrl("track2_1.file")
+        .title("트랙2_1").build());
+    AudioTrack audioTrack2_2 = audioTrackRepository.save(AudioTrack.builder()
+        .audioFileUrl("track2_2.file")
+        .title("트랙2_2").build());
+
+    audioGuideTrackContainerRepository.save(AudioGuideTrackContainer.builder()
+        .audioGuide(audioGuide2)
+        .audioTrack(audioTrack2_2)
+        .orderNumber(2).build());
+    audioGuideTrackContainerRepository.save(AudioGuideTrackContainer.builder()
+        .audioGuide(audioGuide2)
+        .audioTrack(audioTrack2_1)
+        .orderNumber(1).build());
+
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
   @ApiIgnore
   @PostMapping("/audio-guides/dump")
   public ResponseEntity<Void> addDumpData() {

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioGuide.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioGuide.java
@@ -42,6 +42,7 @@ public class AudioGuide extends BaseTimeEntity {
   private Set<String> images = new HashSet<>();
 
   @OneToMany(mappedBy = "audioGuide", fetch = FetchType.EAGER)
+  @OrderBy(value = "orderNumber ASC")
   private Set<AudioGuideTrackContainer> tracks = new HashSet<>();
 
   @OneToMany(mappedBy = "audioGuide", fetch = FetchType.EAGER)

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
@@ -1,0 +1,34 @@
+package team_mic.here_and_there.backend.audio_guide.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResAudioTrackInfoItemDto {
+
+  private Long audioTrackId;
+
+  private String title;
+
+  private String runningTime;
+
+  private String image;
+
+  private String audioFileUrl;
+
+  private String placeName;
+
+  private String placeAddress;
+
+  @Builder
+  private ResAudioTrackInfoItemDto(Long audioTrackId, String title, String runningTime,
+      String image, String audioFileUrl, String placeName, String placeAddress) {
+    this.audioTrackId = audioTrackId;
+    this.title = title;
+    this.runningTime = runningTime;
+    this.image = image;
+    this.audioFileUrl = audioFileUrl;
+    this.placeName = placeName;
+    this.placeAddress = placeAddress;
+  }
+}

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
@@ -20,9 +20,12 @@ public class ResAudioTrackInfoItemDto {
 
   private String placeAddress;
 
+  private Integer orderNumber;
+
   @Builder
   private ResAudioTrackInfoItemDto(Long audioTrackId, String title, String runningTime,
-      String image, String audioFileUrl, String placeName, String placeAddress) {
+      String image, String audioFileUrl, String placeName, String placeAddress,
+      Integer orderNumber) {
     this.audioTrackId = audioTrackId;
     this.title = title;
     this.runningTime = runningTime;
@@ -30,5 +33,6 @@ public class ResAudioTrackInfoItemDto {
     this.audioFileUrl = audioFileUrl;
     this.placeName = placeName;
     this.placeAddress = placeAddress;
+    this.orderNumber = orderNumber;
   }
 }

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoListDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoListDto.java
@@ -9,12 +9,16 @@ public class ResAudioTrackInfoListDto {
 
   private Long audioGuideId;
 
+  private String audioGuideTitle;
+
   private List<ResAudioTrackInfoItemDto> audioTrackInfoList;
 
   @Builder
   private ResAudioTrackInfoListDto(Long audioGuideId,
+      String audioGuideTitle,
       List<ResAudioTrackInfoItemDto> audioTrackInfoList) {
     this.audioGuideId = audioGuideId;
+    this.audioGuideTitle = audioGuideTitle;
     this.audioTrackInfoList = audioTrackInfoList;
   }
 }

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoListDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoListDto.java
@@ -1,0 +1,20 @@
+package team_mic.here_and_there.backend.audio_guide.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResAudioTrackInfoListDto {
+
+  private Long audioGuideId;
+
+  private List<ResAudioTrackInfoItemDto> audioTrackInfoList;
+
+  @Builder
+  private ResAudioTrackInfoListDto(Long audioGuideId,
+      List<ResAudioTrackInfoItemDto> audioTrackInfoList) {
+    this.audioGuideId = audioGuideId;
+    this.audioTrackInfoList = audioTrackInfoList;
+  }
+}

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioGuideService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioGuideService.java
@@ -91,4 +91,9 @@ public class AudioGuideService {
     tags.forEach(audioGuideTag -> list.add(audioGuideTag.getTag().getName()));
     return list;
   }
+
+  public AudioGuide findAudioGuideById(Long audioGuideId) {
+    return audioGuideRepository.findById(audioGuideId)
+        .orElseThrow(() -> new NoSuchElementException()); //TODO: custom exception
+  }
 }

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
@@ -1,0 +1,52 @@
+package team_mic.here_and_there.backend.audio_guide.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuide;
+import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuideTrackContainer;
+import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioTrack;
+import team_mic.here_and_there.backend.audio_guide.domain.repository.AudioGuideRepository;
+import team_mic.here_and_there.backend.audio_guide.domain.repository.AudioTrackRepository;
+import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioTrackInfoItemDto;
+import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioTrackInfoListDto;
+
+@RequiredArgsConstructor
+@Service
+public class AudioTrackService {
+
+  private final AudioGuideService audioGuideService;
+
+  private final AudioTrackRepository audioTrackRepository;
+
+  public ResAudioTrackInfoListDto getAudioGuidesTrackList(Long audioGuideId) {
+
+    AudioGuide audioGuide = audioGuideService.findAudioGuideById(audioGuideId);
+
+    List<ResAudioTrackInfoItemDto> trackList = audioGuide.getTracks().parallelStream()
+        .map(audioGuideTrackContainer -> toAudioTrackInfoItem(audioGuideTrackContainer))
+        .collect(Collectors.toList());
+
+    return ResAudioTrackInfoListDto.builder()
+        .audioGuideId(audioGuide.getId())
+        .audioTrackInfoList(trackList)
+        .build();
+  }
+
+  private ResAudioTrackInfoItemDto toAudioTrackInfoItem(
+      AudioGuideTrackContainer audioGuideTrackContainer) {
+
+    AudioTrack track = audioGuideTrackContainer.getAudioTrack();
+
+    return ResAudioTrackInfoItemDto.builder()
+        .audioTrackId(track.getId())
+        .audioFileUrl(track.getAudioFileUrl())
+        .image(track.getImage())
+        .title(track.getTitle())
+        .runningTime(track.getRunningTime())
+        .placeName(track.getPlaceName())
+        .placeAddress(track.getPlaceAddress())
+        .build();
+  }
+}

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
@@ -30,6 +30,7 @@ public class AudioTrackService {
 
     return ResAudioTrackInfoListDto.builder()
         .audioGuideId(audioGuide.getId())
+        .audioGuideTitle(audioGuide.getTitle())
         .audioTrackInfoList(trackList)
         .build();
   }
@@ -41,6 +42,7 @@ public class AudioTrackService {
 
     return ResAudioTrackInfoItemDto.builder()
         .audioTrackId(track.getId())
+        .orderNumber(audioGuideTrackContainer.getOrderNumber())
         .audioFileUrl(track.getAudioFileUrl())
         .image(track.getImage())
         .title(track.getTitle())


### PR DESCRIPTION
- 오디오가이드 id 에 포함되는 모든 오디오 트랙 정보를 리스트 형태로 내려준다.
- 로컬에서 덤프데이터를 삽입해서 API를 테스트 한다.
- Close #5 