### PR TITLE
[Fix] : 오디오 트랙의 이미지 칼럼을 List 로 변경

### DIFF
--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideDumpController.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideDumpController.java
@@ -3,6 +3,7 @@ package team_mic.here_and_there.backend.audio_guide.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
@@ -28,6 +29,15 @@ public class AudioGuideDumpController {
   public ResponseEntity<Void> insertDumpGuides() {
 
     audioGuideDumpService.insertDumpGuides();
+
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
+  @ApiIgnore
+  @DeleteMapping("/audio-guides/audio-tracks/dump")
+  public ResponseEntity<Void> deleteAllGuideTrackContainers() {
+
+    audioGuideDumpService.deleteAllGuideTrackContainers();
 
     return ResponseEntity.status(HttpStatus.OK).build();
   }

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioTrack.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioTrack.java
@@ -1,5 +1,7 @@
 package team_mic.here_and_there.backend.audio_guide.domain.entity;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,7 +28,11 @@ public class AudioTrack extends BaseTimeEntity {
 
   private String title;
 
-  private String image;
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(name = "audio_track_images", joinColumns = {
+      @JoinColumn(name = "audio_track_id")})
+  @Column(name = "image_url")
+  private List<String> images = new ArrayList<>();
 
   @OneToMany(mappedBy = "audioTrack", fetch = FetchType.EAGER)
   private Set<AudioGuideTrackContainer> guides = new HashSet<>();
@@ -40,12 +46,12 @@ public class AudioTrack extends BaseTimeEntity {
   private Double locationLongitude;
 
   @Builder
-  private AudioTrack(String audioFileUrl, String runningTime, String title, String image,
+  private AudioTrack(String audioFileUrl, String runningTime, String title, List<String> images,
       String placeName, String placeAddress, Double locationLatitude, Double locationLongitude) {
     this.audioFileUrl = audioFileUrl;
     this.runningTime = runningTime;
     this.title = title;
-    this.image = image;
+    this.images = images;
     this.placeName = placeName;
     this.placeAddress = placeAddress;
     this.locationLatitude = locationLatitude;

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
@@ -2,6 +2,7 @@ package team_mic.here_and_there.backend.audio_guide.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,7 +22,7 @@ public class ResAudioTrackInfoItemDto {
   private String runningTime;
 
   @ApiModelProperty(notes = "오디오 트랙 이미지")
-  private String image;
+  private List<String> images;
 
   @ApiModelProperty(notes = "오디오 트랙의 오디오 파일 url")
   private String audioFileUrl;
@@ -37,12 +38,12 @@ public class ResAudioTrackInfoItemDto {
 
   @Builder
   private ResAudioTrackInfoItemDto(Long audioTrackId, String title, String runningTime,
-      String image, String audioFileUrl, String placeName, String placeAddress,
+      List<String> images, String audioFileUrl, String placeName, String placeAddress,
       Integer orderNumber) {
     this.audioTrackId = audioTrackId;
     this.title = title;
     this.runningTime = runningTime;
-    this.image = image;
+    this.images = images;
     this.audioFileUrl = audioFileUrl;
     this.placeName = placeName;
     this.placeAddress = placeAddress;

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioGuideDumpService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioGuideDumpService.java
@@ -1,5 +1,6 @@
 package team_mic.here_and_there.backend.audio_guide.service;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +30,13 @@ public class AudioGuideDumpService {
     List<AudioGuide> audioGuideList = audioGuideRepository.findAll();
 
     AudioTrack track1 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png")
-        .title("Mangwon-dong introduction 1")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("Mangwon-dong introduction 1")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/A+Thousand+Years+.mp3")
         .placeName("Mangwon-Station")
@@ -40,9 +45,13 @@ public class AudioGuideDumpService {
         .build());
 
     AudioTrack track2 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png")
-        .title("Mangwon-dong introduction 2")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("Mangwon-dong introduction 2")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/Butterfly+and+cat.mp3")
         .placeName("Mangwon-Station")
@@ -51,9 +60,13 @@ public class AudioGuideDumpService {
         .build());
 
     AudioTrack track3 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png")
-        .title("Mangwonjeong Pavilion Site")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("Mangwonjeong Pavilion Site")
         .placeName("Mangwon-Station")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/Comethru.mp3")
@@ -62,9 +75,13 @@ public class AudioGuideDumpService {
         .build());
 
     AudioTrack track4 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png")
-        .title("Hangang introduction")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("Hangang introduction")
         .placeName("Mangwon-Station")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/Dandelion.mp3")
@@ -73,9 +90,13 @@ public class AudioGuideDumpService {
         .build());
 
     AudioTrack track5 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png")
-        .title("Background of Ridangil")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("Background of Ridangil")
         .placeName("Mangwon-Station")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/Do+you+want+to+go+see+the+stars.mp3")
@@ -84,9 +105,13 @@ public class AudioGuideDumpService {
         .build());
 
     AudioTrack track6 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png")
-        .title("About Mangnidan-gil")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("About Mangnidan-gil")
         .placeName("Mangwon-Station")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/FREEDOM.mp3")
@@ -95,9 +120,13 @@ public class AudioGuideDumpService {
         .build());
 
     AudioTrack track7 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png")
-        .title("About Traditional market")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("About Traditional market")
         .placeName("Mangwon-Station")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/Let's+take+time.mp3")
@@ -106,9 +135,13 @@ public class AudioGuideDumpService {
         .build());
 
     AudioTrack track8 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png")
-        .title("Mangwon market introduction")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("Mangwon market introduction")
         .placeName("Mangwon-Station")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/November+Rain.mp3")
@@ -117,9 +150,13 @@ public class AudioGuideDumpService {
         .build());
 
     AudioTrack track9 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png")
-        .title("Mangwon market introduction2")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("Mangwon market introduction2")
         .placeName("Mangwon-Station")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/Whale.mp3")
@@ -128,9 +165,13 @@ public class AudioGuideDumpService {
         .build());
 
     AudioTrack track10 = audioTrackRepository.save(AudioTrack.builder()
-        .image(
-            "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png")
-        .title("Mangwon market introduction3")
+        .images(new ArrayList<String>() {{
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image1.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image3.png");
+                  add("https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/images/test_image2.png");
+                }}
+        ).title("Mangwon market introduction3")
         .placeName("Mangwon-Station")
         .audioFileUrl(
             "https://here-and-there.s3.ap-northeast-2.amazonaws.com/audio-guides/audio_tracks/audio-files/Whenever+Wherever.mp3")
@@ -415,5 +456,9 @@ public class AudioGuideDumpService {
             .audioGuide(audioGuide8)
             .build()
     );
+  }
+
+  public void deleteAllGuideTrackContainers() {
+    audioGuideTrackContainerRepository.deleteAll();
   }
 }

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
@@ -43,7 +43,7 @@ public class AudioTrackService {
         .audioTrackId(track.getId())
         .orderNumber(audioGuideTrackContainer.getOrderNumber())
         .audioFileUrl(track.getAudioFileUrl())
-        .image(track.getImage())
+        .images(track.getImages())
         .title(track.getTitle())
         .runningTime(track.getRunningTime())
         .placeName(track.getPlaceName())


### PR DESCRIPTION
- 하나의 오디오 트랙이 다수의 이미지를 가질 수 있도록 변경
- 새로운 덤프데이터를 삽입하기 위해 기존의 모든  audio guide track container를
삭제하는 메소드를 서비스에  추가
- 다수의 이미지를 삽입하는 오디오 트랙 덤프데이터로 변경

- Close #16