### PR TITLE
[Bug] 보행자 경로 Direction API 에서 폴리라인이 잘리는 버그 해결

### DIFF
--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/service/DirectionApiService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/service/DirectionApiService.java
@@ -90,7 +90,7 @@ public class DirectionApiService {
       finalBuilder.queryParam("endX", endTrack.getLocationLongitude())
           .queryParam("endY", endTrack.getLocationLatitude());
 
-      TmapApiBaseResModelDto modelDto = callPedestrianDirectionsApi(builder.build());
+      TmapApiBaseResModelDto modelDto = callPedestrianDirectionsApi(finalBuilder.build());
       getCoordinatesDirectionList(modelDto, directionList);
     }
 


### PR DESCRIPTION
- 1~7까지는 그려지지만 7~9까지 그려지지 않는 버그 해결
- tmap에 api 콜을 할때 마지막 request에 대한 uri builder 를 잘못 전달한 원인
- Close #34