### PR TITLE
[Feat] Trip tips 글콘텐츠 api 설계

### DIFF
--- a/src/main/java/team_mic/here_and_there/backend/attraction/domain/entity/TouristArea.java
+++ b/src/main/java/team_mic/here_and_there/backend/attraction/domain/entity/TouristArea.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team_mic.here_and_there.backend.common.domain.BaseTimeEntity;
 import team_mic.here_and_there.backend.common.domain.Language;
 
 import javax.persistence.*;
@@ -12,7 +13,7 @@ import javax.persistence.*;
 @Getter
 @Table(name = "tourist_areas")
 @Entity
-public class TouristArea {
+public class TouristArea extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/team_mic/here_and_there/backend/audio_course/domain/entity/AudioCourseElement.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_course/domain/entity/AudioCourseElement.java
@@ -10,12 +10,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team_mic.here_and_there.backend.common.domain.BaseTimeEntity;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "audio_course_elements")
 @Entity
-public class AudioCourseElement {
+public class AudioCourseElement extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/team_mic/here_and_there/backend/audio_course/domain/entity/AudioCourseElementLanguageContent.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_course/domain/entity/AudioCourseElementLanguageContent.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team_mic.here_and_there.backend.common.domain.BaseTimeEntity;
 import team_mic.here_and_there.backend.common.domain.Language;
 
 import javax.persistence.*;
@@ -12,7 +13,7 @@ import javax.persistence.*;
 @Getter
 @Table(name = "audio_course_element_language_contents")
 @Entity
-public class AudioCourseElementLanguageContent {
+public class AudioCourseElementLanguageContent extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/team_mic/here_and_there/backend/audio_course/domain/entity/AudioGuideCourse.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_course/domain/entity/AudioGuideCourse.java
@@ -12,12 +12,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuide;
+import team_mic.here_and_there.backend.common.domain.BaseTimeEntity;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "audio_guide_courses")
 @Entity
-public class AudioGuideCourse {
+public class AudioGuideCourse extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioGuideLanguageContent.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioGuideLanguageContent.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team_mic.here_and_there.backend.common.domain.BaseTimeEntity;
 import team_mic.here_and_there.backend.common.domain.Language;
 
 import javax.persistence.*;
@@ -12,7 +13,7 @@ import javax.persistence.*;
 @Getter
 @Table(name = "audio_guide_language_contents")
 @Entity
-public class AudioGuideLanguageContent {
+public class AudioGuideLanguageContent extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioGuideTrackContainer.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioGuideTrackContainer.java
@@ -6,12 +6,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import team_mic.here_and_there.backend.common.domain.BaseTimeEntity;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "audio_guide_track_containers")
 @Entity
-public class AudioGuideTrackContainer {
+public class AudioGuideTrackContainer extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioTrackLanguageContent.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/entity/AudioTrackLanguageContent.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team_mic.here_and_there.backend.common.domain.BaseTimeEntity;
 import team_mic.here_and_there.backend.common.domain.Language;
 
 import javax.persistence.*;
@@ -12,7 +13,7 @@ import javax.persistence.*;
 @Getter
 @Table(name = "audio_track_language_contents")
 @Entity
-public class AudioTrackLanguageContent {
+public class AudioTrackLanguageContent extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideListDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideListDto.java
@@ -1,6 +1,8 @@
 package team_mic.here_and_there.backend.audio_guide.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,8 +12,10 @@ import java.util.List;
 @JsonPropertyOrder({"category", "language", "audioGuideList"})
 public class ResAudioGuideListDto {
 
+  @ApiModelProperty("오디오 가이드의 카테고리")
   private String category;
 
+  @ApiModelProperty("언어 버전")
   private String language;
 
   private List<ResAudioGuideItemDto> audioGuideList;

--- a/src/main/java/team_mic/here_and_there/backend/location_tag/domain/entity/AudioGuideTag.java
+++ b/src/main/java/team_mic/here_and_there/backend/location_tag/domain/entity/AudioGuideTag.java
@@ -1,5 +1,6 @@
 package team_mic.here_and_there.backend.location_tag.domain.entity;
 
+import com.fasterxml.jackson.databind.ser.Serializers.Base;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,12 +8,13 @@ import lombok.NoArgsConstructor;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuide;
 
 import javax.persistence.*;
+import team_mic.here_and_there.backend.common.domain.BaseTimeEntity;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "audio_guide_tags")
 @Entity
-public class AudioGuideTag {
+public class AudioGuideTag extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/team_mic/here_and_there/backend/trips_tip/controller/TripTipController.java
+++ b/src/main/java/team_mic/here_and_there/backend/trips_tip/controller/TripTipController.java
@@ -2,13 +2,16 @@ package team_mic.here_and_there.backend.trips_tip.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import team_mic.here_and_there.backend.audio_guide.exception.NoParameterException;
 import team_mic.here_and_there.backend.trips_tip.dto.response.ResTripTipsListDto;
 import team_mic.here_and_there.backend.trips_tip.service.TripTipsService;
 
@@ -18,16 +21,43 @@ import team_mic.here_and_there.backend.trips_tip.service.TripTipsService;
 public class TripTipController {
 
   private final TripTipsService tipsService;
-/*
-  @ApiOperation(value = "메인 화면 하단의 여행 팁 리스트",
-      notes = "현재 4개의 여행 팁 덤프 데이터가 내려옵니다.")
+
+  @ApiOperation(value = "메인 화면 하단의 대표 2개의 글 콘텐츠 리스트",
+      notes = "* 메인 화면 하단에 삽입되는 2개의 고정 글 콘텐츠가 제공됩니다.")
   @ApiResponses({
       @ApiResponse(code = 200, message = "OK"),
+      @ApiResponse(code = 400, message = "No parameter Error"),
       @ApiResponse(code = 404, message = "No Trip tips data in DB"),
       @ApiResponse(code = 500, message = "Internal Server Error")
   })
-  @GetMapping("/trip-tips")
-  public ResponseEntity<ResTripTipsListDto> getTripTipsList() {
-    return ResponseEntity.status(HttpStatus.OK).body(tipsService.getTripTipsList());
-  }*/
+  @GetMapping("/v1/trip-tips/main")
+  public ResponseEntity<ResTripTipsListDto> getMainFixedTripTipsList(
+      @ApiParam(value = "언어버전", required = true, example = "kor")
+      @RequestParam(value = "lan") String language
+  ) {
+    if (language == null) {
+      throw new NoParameterException();
+    }
+
+    return ResponseEntity.status(HttpStatus.OK).body(tipsService.getMainFixedTripTipsList(language));
+  }
+
+  @ApiOperation(value = "메인 화면 하단의 글 콘텐츠 리스트 모두 보기",
+      notes = "* 메인화면 하단의 글 콘텐츠 view all 을 클릭할 경우, 모든 글 콘텐츠가 조회수 순으로 제공됩니다.")
+  @ApiResponses({
+      @ApiResponse(code = 200, message = "OK"),
+      @ApiResponse(code = 400, message = "No parameter Error"),
+      @ApiResponse(code = 404, message = "No Trip tips data in DB"),
+      @ApiResponse(code = 500, message = "Internal Server Error")
+  })
+  @GetMapping("/v1/trip-tips")
+  public ResponseEntity<ResTripTipsListDto> getAllTripTipsListOrderByViewCount(
+      @ApiParam(value = "언어버전", required = true, example = "kor")
+      @RequestParam(value = "lan") String language
+  ) {
+    if (language == null) {
+      throw new NoParameterException();
+    }
+    return ResponseEntity.status(HttpStatus.OK).body(tipsService.getAllTripTipsListOrderByViewCount(language));
+  }
 }

--- a/src/main/java/team_mic/here_and_there/backend/trips_tip/domain/entity/AudioGuideTripsTipContainer.java
+++ b/src/main/java/team_mic/here_and_there/backend/trips_tip/domain/entity/AudioGuideTripsTipContainer.java
@@ -7,12 +7,13 @@ import lombok.NoArgsConstructor;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuide;
 
 import javax.persistence.*;
+import team_mic.here_and_there.backend.common.domain.BaseTimeEntity;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "audio_guide_trips_tip_containers")
 @Entity
-public class AudioGuideTripsTipContainer {
+public class AudioGuideTripsTipContainer extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/team_mic/here_and_there/backend/trips_tip/domain/entity/TripTip.java
+++ b/src/main/java/team_mic/here_and_there/backend/trips_tip/domain/entity/TripTip.java
@@ -1,7 +1,5 @@
 package team_mic.here_and_there.backend.trips_tip.domain.entity;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/team_mic/here_and_there/backend/trips_tip/domain/repository/TripTipRepository.java
+++ b/src/main/java/team_mic/here_and_there/backend/trips_tip/domain/repository/TripTipRepository.java
@@ -2,6 +2,7 @@ package team_mic.here_and_there.backend.trips_tip.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import team_mic.here_and_there.backend.common.domain.Language;
 import team_mic.here_and_there.backend.trips_tip.domain.entity.TripTip;
 
 import java.util.List;
@@ -9,5 +10,5 @@ import java.util.List;
 @Repository
 public interface TripTipRepository extends JpaRepository<TripTip, Long> {
 
-  List<TripTip> findTop4ByOrderByCreatedTimeDesc();
+  List<TripTip> findAllByLanguageOrderByViewCountDesc(Language language);
 }

--- a/src/main/java/team_mic/here_and_there/backend/trips_tip/dto/response/ResTripTipItemDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/trips_tip/dto/response/ResTripTipItemDto.java
@@ -7,26 +7,31 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@JsonPropertyOrder({"tripTipId", "title", "imageUrl", "description"})
+@JsonPropertyOrder({"tripTipId", "title", "thumbnailImageUrl", "thumbnailDescription", "contentsUrl"})
 public class ResTripTipItemDto {
 
-  @ApiModelProperty(notes = "여행 팁 id")
+  @ApiModelProperty(notes = "글 콘텐츠 id")
   private Long tripTipId;
 
-  @ApiModelProperty(notes = "여행 팁 메인 이미지 url")
-  private String imageUrl;
+  @ApiModelProperty(notes = "글 콘텐츠 썸네일 이미지 url")
+  private String thumbnailImageUrl;
 
-  @ApiModelProperty(notes = "여행 팁 제목")
+  @ApiModelProperty(notes = "글 콘텐츠 제목")
   private String title;
 
-  @ApiModelProperty(notes = "여행 팁 내용")
-  private String description;
+  @ApiModelProperty(notes = "글 콘텐츠 썸네일 내용")
+  private String thumbnailDescription;
+
+  @ApiModelProperty(notes = "글 콘텐츠 노션 url")
+  private String contentsUrl;
 
   @Builder
-  private ResTripTipItemDto(Long tripTipId, String imageUrl, String title, String description) {
+  private ResTripTipItemDto(Long tripTipId, String thumbnailImageUrl, String title,
+      String thumbnailDescription, String contentsUrl) {
     this.tripTipId = tripTipId;
-    this.imageUrl = imageUrl;
+    this.thumbnailImageUrl = thumbnailImageUrl;
     this.title = title;
-    this.description = description;
+    this.thumbnailDescription = thumbnailDescription;
+    this.contentsUrl = contentsUrl;
   }
 }

--- a/src/main/java/team_mic/here_and_there/backend/trips_tip/dto/response/ResTripTipsListDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/trips_tip/dto/response/ResTripTipsListDto.java
@@ -1,17 +1,24 @@
 package team_mic.here_and_there.backend.trips_tip.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@JsonPropertyOrder({"language", "tripTipsList"})
 public class ResTripTipsListDto {
+
+  @ApiModelProperty("언어 버전")
+  private String language;
 
   private List<ResTripTipItemDto> tripTipsList;
 
   @Builder
-  private ResTripTipsListDto(List<ResTripTipItemDto> tripTipsList) {
+  private ResTripTipsListDto(String language, List<ResTripTipItemDto> tripTipsList) {
+    this.language = language;
     this.tripTipsList = tripTipsList;
   }
 }

--- a/src/main/java/team_mic/here_and_there/backend/trips_tip/service/TripTipsService.java
+++ b/src/main/java/team_mic/here_and_there/backend/trips_tip/service/TripTipsService.java
@@ -1,7 +1,9 @@
 package team_mic.here_and_there.backend.trips_tip.service;
 
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import team_mic.here_and_there.backend.common.domain.Language;
 import team_mic.here_and_there.backend.trips_tip.domain.entity.TripTip;
 import team_mic.here_and_there.backend.trips_tip.domain.repository.TripTipRepository;
 import team_mic.here_and_there.backend.trips_tip.dto.response.ResTripTipItemDto;
@@ -16,6 +18,64 @@ import team_mic.here_and_there.backend.trips_tip.exception.NoTripTipsException;
 public class TripTipsService {
 
   private final TripTipRepository tripTipRepository;
+
+  public ResTripTipsListDto getMainFixedTripTipsList(String language) {
+    List<ResTripTipItemDto> itemList = new ArrayList<>();
+    Long[] fixedTipIds = new Long[2];
+
+    if(language.equals(Language.KOREAN.getVersion())){
+      fixedTipIds[0] = 9L;
+      fixedTipIds[1] = 11L;
+    }
+
+    if(language.equals(Language.ENGLISH.getVersion())){
+      fixedTipIds[0] = 2L;
+      fixedTipIds[1] = 5L;
+    }
+
+    for(Long tipId : fixedTipIds){
+      TripTip tip = tripTipRepository.findById(tipId).orElseThrow(NoTripTipsException::new);
+      itemList.add(toTripTipItemDto(tip));
+    }
+
+    return ResTripTipsListDto.builder()
+        .language(language)
+        .tripTipsList(itemList)
+        .build();
+  }
+
+  private ResTripTipItemDto toTripTipItemDto(TripTip tip) {
+    return ResTripTipItemDto.builder()
+        .tripTipId(tip.getId())
+        .title(tip.getTitle())
+        .thumbnailImageUrl(tip.getThumbnailImage())
+        .contentsUrl(tip.getContentsUrl())
+        .thumbnailDescription(tip.getThumbnailDescription())
+        .build();
+  }
+
+  public ResTripTipsListDto getAllTripTipsListOrderByViewCount(String language) {
+    List<ResTripTipItemDto> itemList = new ArrayList<>();
+    List<TripTip> tips = new ArrayList<>();
+
+    if(language.equals(Language.KOREAN.getVersion())){
+      tips = tripTipRepository.findAllByLanguageOrderByViewCountDesc(Language.KOREAN);
+    }
+
+    if(language.equals(Language.ENGLISH.getVersion())){
+      tips = tripTipRepository.findAllByLanguageOrderByViewCountDesc(Language.ENGLISH);
+    }
+
+    if(tips.isEmpty()){
+      throw new NoTripTipsException();
+    }
+    tips.forEach(tip -> itemList.add(toTripTipItemDto(tip)));
+
+    return ResTripTipsListDto.builder()
+        .language(language)
+        .tripTipsList(itemList)
+        .build();
+  }
 /*
   public ResTripTipsListDto getTripTipsList() {
 


### PR DESCRIPTION
- 메인 화면의 고정 2개의 글 콘텐츠 데이터 제공 api
- 메인화면 글콘텐츠 view all의 콘텐츠 데이터 : 조회수 많은 순 정렬
- 기존 모든 entity BaseTimeEntity 상속
- Close #41