### PR TITLE
[AudioGuide] 오디오가이드 화면 API 설계

### DIFF
--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/repository/AudioGuideLanguageContentRepository.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/repository/AudioGuideLanguageContentRepository.java
@@ -1,9 +1,14 @@
 package team_mic.here_and_there.backend.audio_guide.domain.repository;
 
+import java.util.List;
+import org.apache.commons.codec.language.bm.Lang;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuideLanguageContent;
+import team_mic.here_and_there.backend.common.domain.Language;
 
 @Repository
 public interface AudioGuideLanguageContentRepository extends JpaRepository<AudioGuideLanguageContent, Long> {
+  List<AudioGuideLanguageContent> findAllByLanguageOrderByViewCountDesc(Language language);
+  List<AudioGuideLanguageContent> findAllByLanguageOrderByPlayingCountDesc(Language language);
 }

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/repository/AudioGuideRepository.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/domain/repository/AudioGuideRepository.java
@@ -1,5 +1,6 @@
 package team_mic.here_and_there.backend.audio_guide.domain.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuide;

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideCategoryListDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideCategoryListDto.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Getter
 @JsonPropertyOrder({"category", "language", "audioGuideList"})
-public class ResAudioGuideListDto {
+public class ResAudioGuideCategoryListDto {
 
   @ApiModelProperty("오디오 가이드의 카테고리")
   private String category;
@@ -21,7 +21,7 @@ public class ResAudioGuideListDto {
   private List<ResAudioGuideItemDto> audioGuideList;
 
   @Builder
-  private ResAudioGuideListDto(String category, String language,
+  private ResAudioGuideCategoryListDto(String category, String language,
       List<ResAudioGuideItemDto> audioGuideList) {
     this.category = category;
     this.language = language;

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideItemDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideItemDto.java
@@ -8,14 +8,14 @@ import lombok.Getter;
 import java.util.List;
 
 @Getter
-@JsonPropertyOrder({"audioGuideId", "title", "imageUrl", "tags"})
+@JsonPropertyOrder({"audioGuideId", "title", "thumbnailImageUrl", "tags"})
 public class ResAudioGuideItemDto {
 
   @ApiModelProperty(notes = "오디오 가이드 id")
   private Long audioGuideId;
 
   @ApiModelProperty(notes = "오디오 가이드 메인 이미지 url")
-  private String imageUrl;
+  private String thumbnailImageUrl;
 
   @ApiModelProperty(notes = "오디오 가이드 제목")
   private String title;
@@ -24,9 +24,9 @@ public class ResAudioGuideItemDto {
   private List<String> tags;
 
   @Builder
-  private ResAudioGuideItemDto(Long audioGuideId, String imageUrl, String title, List<String> tags) {
+  private ResAudioGuideItemDto(Long audioGuideId, String thumbnailImageUrl, String title, List<String> tags) {
     this.audioGuideId = audioGuideId;
-    this.imageUrl = imageUrl;
+    this.thumbnailImageUrl = thumbnailImageUrl;
     this.title = title;
     this.tags = tags;
   }

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideOrderingListDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideOrderingListDto.java
@@ -1,0 +1,32 @@
+package team_mic.here_and_there.backend.audio_guide.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"language", "orderBy", "guideCounts", "audioGuideList"})
+public class ResAudioGuideOrderingListDto {
+
+  @ApiModelProperty(value = "언어 버전")
+  private String language;
+
+  @ApiModelProperty(value = "정렬 기준")
+  private String orderBy;
+
+  @ApiModelProperty(value = "response 에 포함된 오디오 가이드 개수")
+  private Integer guideCounts;
+
+  private List<ResAudioGuideItemDto> audioGuideList;
+
+  @Builder
+  private ResAudioGuideOrderingListDto(String language, String orderBy, Integer guideCounts,
+      List<ResAudioGuideItemDto> audioGuideList){
+    this.language = language;
+    this.orderBy = orderBy;
+    this.guideCounts = guideCounts;
+    this.audioGuideList = audioGuideList;
+  }
+}

--- a/src/main/java/team_mic/here_and_there/backend/trips_tip/controller/TripTipController.java
+++ b/src/main/java/team_mic/here_and_there/backend/trips_tip/controller/TripTipController.java
@@ -27,7 +27,10 @@ public class TripTipController {
   private final TripTipsService tipsService;
 
   @ApiOperation(value = "메인 화면 하단의 대표 2개의 글 콘텐츠 리스트",
-      notes = "* 메인 화면 하단에 삽입되는 2개의 고정 글 콘텐츠가 제공됩니다.")
+      notes = "* 메인 화면 하단에 삽입되는 2개의 고정 글 콘텐츠가 제공됩니다."
+          + "[lag param 종류]\n" +
+          "kor : 한국어 버전\n" +
+          "eng : 영어 버전")
   @ApiResponses({
       @ApiResponse(code = 200, message = "OK"),
       @ApiResponse(code = 400, message = "No parameter Error"),
@@ -47,7 +50,10 @@ public class TripTipController {
   }
 
   @ApiOperation(value = "메인 화면 하단의 글 콘텐츠 리스트 모두 보기",
-      notes = "* 메인화면 하단의 글 콘텐츠 view all 을 클릭할 경우, 모든 글 콘텐츠가 조회수 순으로 제공됩니다.")
+      notes = "* 메인화면 하단의 글 콘텐츠 view all 을 클릭할 경우, 모든 글 콘텐츠가 조회수 순으로 제공됩니다."
+          + "[lag param 종류]\n" +
+          "kor : 한국어 버전\n" +
+          "eng : 영어 버전")
   @ApiResponses({
       @ApiResponse(code = 200, message = "OK"),
       @ApiResponse(code = 400, message = "No parameter Error"),


### PR DESCRIPTION
- 조회수 순 가이드 정렬 리스트 제공 api
- 재생순 가이드 정렬 리스트 제공 api
- 랜덤 가이드 리스트 제공 api
- 기존 메인화면의 랜덤 카테고리 가이드를 랜덤 order 제공 api로 통합
- #46