### PR TITLE
[Feat]  오디오 가이드 상세 페이지 조회 api

### DIFF
--- a/src/main/java/team_mic/here_and_there/backend/audio_course/dto/response/ResAudioCourseInfoItemDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_course/dto/response/ResAudioCourseInfoItemDto.java
@@ -1,0 +1,39 @@
+package team_mic.here_and_there.backend.audio_course.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonPropertyOrder({"audioCourseId", "title", "estimatedTravelTime",
+    "courseOrderNumber", "hasRelatedAttraction", "relatedTourApiAttractionContentId",
+    "relatedTourApiAttractionContentTypeId", "courseImages"})
+public class ResAudioCourseInfoItemDto {
+
+  @ApiModelProperty(value = "코스 요소의 아이디")
+  private Long audioCourseId;
+
+  @ApiModelProperty(value = "코스 제목")
+  private String title;
+
+  @ApiModelProperty(value = "코스 예상 소요 시간")
+  private String estimatedTravelTime;
+
+  @ApiModelProperty(value = "오디오 가이드 내 해당 코스 요소의 순서")
+  private Integer courseOrderNumber;
+
+  @ApiModelProperty(value = "코스 요소에 연결된 tour api 관광지의 존재 여부")
+  private Boolean hasRelatedAttraction;
+
+  @ApiModelProperty(value = "관련 tour api 관광지의 content id")
+  private Long relatedTourApiAttractionContentId;
+
+  @ApiModelProperty(value = "관련 tour api 관광지의 content type id")
+  private Integer relatedTourApiAttractionContentTypeId;
+
+  @ApiModelProperty(value = "코스 이미지 url 리스트")
+  private List<String> courseImages;
+}

--- a/src/main/java/team_mic/here_and_there/backend/audio_course/service/AudioCourseService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_course/service/AudioCourseService.java
@@ -1,0 +1,58 @@
+package team_mic.here_and_there.backend.audio_course.service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team_mic.here_and_there.backend.audio_course.domain.entity.AudioCourseElement;
+import team_mic.here_and_there.backend.audio_course.domain.entity.AudioCourseElementLanguageContent;
+import team_mic.here_and_there.backend.audio_course.domain.entity.AudioGuideCourse;
+import team_mic.here_and_there.backend.audio_course.dto.response.ResAudioCourseInfoItemDto;
+import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuide;
+import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuideTrackContainer;
+import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioTrack;
+import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioTrackLanguageContent;
+import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioTrackInfoItemDto;
+
+@RequiredArgsConstructor
+@Service
+public class AudioCourseService {
+
+  public List<ResAudioCourseInfoItemDto> getAudioGuidesCourseList(AudioGuide guide, String language) {
+
+    List<ResAudioCourseInfoItemDto> courseList = guide.getCourse().parallelStream()
+        .map(audioGuideCourse -> toAudioCourseInfoItem(audioGuideCourse, language))
+        .collect(Collectors.toList());
+
+    return courseList;
+  }
+
+  private ResAudioCourseInfoItemDto toAudioCourseInfoItem(
+      AudioGuideCourse audioGuideCourse, String language) {
+
+    AudioCourseElement courseElement = audioGuideCourse.getAudioCourseElement();
+    Optional<AudioCourseElementLanguageContent> languageContent = Optional.empty();
+
+    for(AudioCourseElementLanguageContent content : courseElement.getLanguageContents()){
+      if(content.getLanguage().getVersion().equals(language)){
+        languageContent = Optional.of(content);
+      }
+    }
+
+    AudioCourseElementLanguageContent correspondingContent = languageContent.orElseThrow(
+        NoSuchElementException::new); //TODO : custom exception
+
+    return ResAudioCourseInfoItemDto.builder()
+        .audioCourseId(courseElement.getId())
+        .courseImages(courseElement.getImages())
+        .courseOrderNumber(audioGuideCourse.getOrderNumber())
+        .estimatedTravelTime(courseElement.getEstimatedTravelTime())
+        .title(correspondingContent.getTitle())
+        .hasRelatedAttraction(correspondingContent.getTourApiAttractionContentId()==null ? false : true)
+        .relatedTourApiAttractionContentId(correspondingContent.getTourApiAttractionContentId())
+        .relatedTourApiAttractionContentTypeId(correspondingContent.getTourApiAttractionContentTypeId())
+        .build();
+  }
+}

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideController.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideController.java
@@ -5,16 +5,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuideCategory;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioGuideCategoryListDto;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioGuideOrderingListDto;
+import team_mic.here_and_there.backend.audio_guide.dto.response.ResSingleAudioGuideDetailDto;
 import team_mic.here_and_there.backend.audio_guide.exception.NoParameterException;
 import team_mic.here_and_there.backend.audio_guide.exception.WrongCategoryException;
 import team_mic.here_and_there.backend.audio_guide.service.AudioGuideService;
-import team_mic.here_and_there.backend.audio_guide.service.AudioTrackService;
 
 @Api(tags = "오디오 가이드 API")
 @RestController
@@ -22,7 +23,16 @@ import team_mic.here_and_there.backend.audio_guide.service.AudioTrackService;
 public class AudioGuideController {
 
   private final AudioGuideService audioGuideService;
-  private final AudioTrackService audioTrackService;
+
+  @GetMapping("/v1/audio-guides/{audio-guide-id:^[0-9]+$}")
+  public ResponseEntity<ResSingleAudioGuideDetailDto> getSingleAudioGuideDetail(
+      @PathVariable(value = "audio-guide-id") Long audioGuideId,
+      @ApiParam(value = "언어버전", required = true, example = "kor")
+      @RequestParam(value = "lan") String language){
+
+    return ResponseEntity.status(HttpStatus.OK).body(
+        audioGuideService.getSingleAudioGuideDetail(audioGuideId, language));
+  }
 
   @ApiOperation(value = "정렬기준(조회수, 재생수, 랜덤)으로 count 개수만큼의 오디오 가이드 리스트 조회",
       notes = "[order param 종류]\n" +

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
@@ -7,34 +7,27 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@JsonPropertyOrder({"audioTrackId", "trackOrderNumber", "title", "audioFileUrl", "image",
-    "placeName", "placeAddress",
-    "runningTime", "trackLatitude", "trackLongitude"})
+@JsonPropertyOrder({"audioTrackId", "trackOrderNumber", "title", "audioFileUrl",
+    "runningTime", "images", "trackLatitude", "trackLongitude"})
 public class ResAudioTrackInfoItemDto {
 
   @ApiModelProperty(notes = "오디오 트랙의 id")
   private Long audioTrackId;
 
+  @ApiModelProperty(notes = "오디오 가이드 내부에서 해당 오디오 트랙의 순서 번호")
+  private Integer trackOrderNumber;
+
   @ApiModelProperty(notes = "오디오 트랙의 제목")
   private String title;
+
+  @ApiModelProperty(notes = "오디오 트랙의 오디오 파일 url")
+  private String audioFileUrl;
 
   @ApiModelProperty(notes = "오디오 트랙의 총 시간")
   private String runningTime;
 
   @ApiModelProperty(notes = "오디오 트랙 이미지")
   private List<String> images;
-
-  @ApiModelProperty(notes = "오디오 트랙의 오디오 파일 url")
-  private String audioFileUrl;
-
-  @ApiModelProperty(notes = "오디오 트랙의 장소 이름")
-  private String placeName;
-
-  @ApiModelProperty(notes = "오디오 트랙의 장소 주소")
-  private String placeAddress;
-
-  @ApiModelProperty(notes = "오디오 가이드 내부에서 해당 오디오 트랙의 순서 번호")
-  private Integer trackOrderNumber;
 
   @ApiModelProperty(notes = "오디오 트랙의 위도")
   private Double trackLatitude;
@@ -44,15 +37,13 @@ public class ResAudioTrackInfoItemDto {
 
   @Builder
   private ResAudioTrackInfoItemDto(Long audioTrackId, String title, String runningTime,
-      List<String> images, String audioFileUrl, String placeName, String placeAddress,
+      List<String> images, String audioFileUrl,
       Integer orderNumber, Double trackLatitude, Double trackLongitude) {
     this.audioTrackId = audioTrackId;
     this.title = title;
     this.runningTime = runningTime;
     this.images = images;
     this.audioFileUrl = audioFileUrl;
-    this.placeName = placeName;
-    this.placeAddress = placeAddress;
     this.trackOrderNumber = orderNumber;
     this.trackLatitude = trackLatitude;
     this.trackLongitude = trackLongitude;

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResSingleAudioGuideDetailDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResSingleAudioGuideDetailDto.java
@@ -1,0 +1,61 @@
+package team_mic.here_and_there.backend.audio_guide.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import team_mic.here_and_there.backend.audio_course.dto.response.ResAudioCourseInfoItemDto;
+import team_mic.here_and_there.backend.trips_tip.dto.response.ResTripTipItemDto;
+
+@Getter
+@Builder
+@JsonPropertyOrder({"language", "audioGuideId", "title", "location", "distance",
+    "estimatedTravelTime", "tags", "guideImages", "overviewDescription",
+    "tracksList", "coursesList", "recommendedAudioGuidesList", "recommendedContentsList"})
+public class ResSingleAudioGuideDetailDto {
+
+  @ApiModelProperty(value = "언어 버전")
+  private String language;
+
+  @ApiModelProperty(value = "오디오 가이드 id")
+  private Long audioGuideId;
+
+  //가이드 기본 정보
+  @ApiModelProperty(value = "오디오 가이드 제목")
+  private String title;
+
+  @ApiModelProperty(value = "오디오 가이드 지역 위치 정보")
+  private String location;
+
+  @ApiModelProperty(value = "가이드 총 거리")
+  private String distance;
+
+  @ApiModelProperty(value = "가이드 예상 소요 시간")
+  private String estimatedTravelTime;
+
+  @ApiModelProperty(value = "오디오 가이드 태그 리스트")
+  private List<String> tags;
+
+  @ApiModelProperty(value = "오디오 가이드 이미지 url 리스트")
+  private List<String> guideImages;
+
+  @ApiModelProperty(value = "오디오 가이드 overview 내용")
+  private String overviewDescription;
+
+  //트랙 리스트
+  @ApiModelProperty(value = "오디오 가이드 트랙 리스트")
+  private List<ResAudioTrackInfoItemDto> tracksList;
+
+  //코스 리스트 + 연결 관광지
+  @ApiModelProperty(value = "오디오 가이드 코스 리스트")
+  private List<ResAudioCourseInfoItemDto> coursesList;
+
+  //추천 가이드 리스트
+  @ApiModelProperty(value = "해당 오디오 가이드의 추천 오디오 가이드 리스트")
+  private List<ResAudioGuideItemDto> recommendedAudioGuidesList;
+
+  //추천 글콘텐츠
+  @ApiModelProperty(value = "오디오 가이드 추천 글 콘텐츠 리스트")
+  private List<ResTripTipItemDto> recommendedContentsList;
+}

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
@@ -2,63 +2,67 @@ package team_mic.here_and_there.backend.audio_guide.service;
 
 import autovalue.shaded.com.google$.common.primitives.$Primitives;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team_mic.here_and_there.backend.attraction.dto.response.ResAreaAttractionsListDto;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuide;
+import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuideLanguageContent;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuideTrackContainer;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioTrack;
+import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioTrackLanguageContent;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioTrackInfoItemDto;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioTrackInfoListDto;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResNearestAudioTrackDto;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResNearestAudioTrackInfoDto;
+import team_mic.here_and_there.backend.common.domain.Language;
 import team_mic.here_and_there.backend.common.util.DistanceCalculate;
 
 @RequiredArgsConstructor
 @Service
 public class AudioTrackService {
 
-  private final AudioGuideService audioGuideService;
-
   private static final Long RADIUS_METER_BOUNDARY = 50L;
 
-/*
-  public ResAudioTrackInfoListDto getAudioGuidesTrackList(Long audioGuideId) {
 
-    AudioGuide audioGuide = audioGuideService.findAudioGuideById(audioGuideId);
+  public List<ResAudioTrackInfoItemDto> getAudioGuidesTrackList(AudioGuide guide, String language) {
 
-    List<ResAudioTrackInfoItemDto> trackList = audioGuide.getTracks().parallelStream()
-        .map(audioGuideTrackContainer -> toAudioTrackInfoItem(audioGuideTrackContainer))
+    List<ResAudioTrackInfoItemDto> trackList = guide.getTracks().parallelStream()
+        .map(audioGuideTrackContainer -> toAudioTrackInfoItem(audioGuideTrackContainer, language))
         .collect(Collectors.toList());
 
-    return ResAudioTrackInfoListDto.builder()
-        .audioGuideId(audioGuide.getId())
-        .audioGuideTitle(audioGuide.getTitle())
-        .audioTrackInfoList(trackList)
-        .build();
+    return trackList;
   }
 
-  private ResAudioTrackInfoItemDto toAudioTrackInfoItem(
-      AudioGuideTrackContainer audioGuideTrackContainer) {
+  private ResAudioTrackInfoItemDto toAudioTrackInfoItem(AudioGuideTrackContainer audioGuideTrackContainer,
+      String language) {
 
     AudioTrack track = audioGuideTrackContainer.getAudioTrack();
+    Optional<AudioTrackLanguageContent> languageContent = Optional.empty();
+    for(AudioTrackLanguageContent content : track.getLanguageContents()){
+      if(content.getLanguage().getVersion().equals(language)){
+        languageContent = Optional.of(content);
+      }
+    }
+
+    AudioTrackLanguageContent correspondingContent = languageContent.orElseThrow(
+        NoSuchElementException::new);
 
     return ResAudioTrackInfoItemDto.builder()
         .audioTrackId(track.getId())
         .orderNumber(audioGuideTrackContainer.getOrderNumber())
-        .audioFileUrl(track.getAudioFileUrl())
-        .images(track.getImages())
-        .title(track.getTitle())
-        .runningTime(track.getRunningTime())
-        .placeName(track.getPlaceName())
-        .placeAddress(track.getPlaceAddress())
-        .trackLatitude(track.getLocationLatitude())
         .trackLongitude(track.getLocationLongitude())
+        .trackLatitude(track.getLocationLatitude())
+        .images(track.getImages())
+        .title(correspondingContent.getTitle())
+        .audioFileUrl(correspondingContent.getAudioFileUrl())
+        .runningTime(correspondingContent.getRunningTime())
         .build();
   }
-
+/*
   public ResNearestAudioTrackDto getNearestAudioTracks(Long audioGuideId, Double userLatitude,
       Double userLongitude) {
 


### PR DESCRIPTION
- 한/영 언어별 가이드 기본 정보 조회
- 한/영 언어별 가이드 트랙 정보 리스트 조회
- 한/영 언어별 가이드 코스 정보 리스트 조회
- 추천 가이드 리스트 조회
- TODO : 추천 글 콘텐츠의 경우 현재 모두 empty이므로 임시로 빈 리스트 반환 -> 추후에 일반적인 로직 구현하기
- Issue : #46