### PR TITLE
[Feat] 오디오 트랙 폴리라인 API

### DIFF
--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideController.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/controller/AudioGuideController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 import team_mic.here_and_there.backend.audio_guide.domain.entity.AudioGuideCategory;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioGuideCategoryListDto;
+import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioGuideDirectionsDto;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioGuideOrderingListDto;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResPatchedSingleAudioGuideDto;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResSingleAudioGuideDetailDto;
@@ -147,27 +148,27 @@ public class AudioGuideController {
     return ResponseEntity.status(HttpStatus.OK).body(audioGuideService.getAudioGuideCategoryList(category, language));
   }
 
-  /*
-  @ApiOperation(value = "오디오 가이드의 트랙들에 대한 Direction 폴리라인 위경도 정보",
-      notes = "오디오 가이드의 Direction 폴리라인 위경도 리스트 정보를 제공합니다.\n "
+
+  @ApiOperation(value = "오디오 가이드의 트랙들에 대한 Point 위경도와 Direction 폴리라인 위경도 정보",
+      notes = "오디오 가이드의 각 트랙 Point 들의 위경도 리스트 정보와 Direction 폴리라인 위경도 리스트 정보를 제공합니다.\n "
           + "path-variable 에 오디오 가이드의 id를 넣어주세요.\n"
-          + "위경도 정보에 대한 폴리라인 list 는 클라이언트 개발의 편의를 위해 [ {A점 위도, A점 경도}, {B점 위도, B점 경도}, {B점 위도, B점 경도}, {C점 위도, C점 경도}, {C점 위도, C점 경도},{D점 위도, D점 경도}...] 와 같은 형식의 포맷입니다.\n"
-          + "현재 DB에 저장된 오디오 가이드의 id는 1~9까지 존재합니다.\n"
-          + "For Test Application : **북촌 가이드의 id는 9입니다. 북촌 가이드의 경우에만 테스트가 가능합니다.**")
+          + "위경도 정보에 대한 폴리라인 list 는 클라이언트 개발의 편의를 위해 [ {A점 위도, A점 경도}, {B점 위도, B점 경도}, {B점 위도, B점 경도}, {C점 위도, C점 경도}, {C점 위도, C점 경도},{D점 위도, D점 경도}...] 와 같은 형식의 포맷입니다.\n")
   @ApiImplicitParam(name = "audio-guide-id", value = "오디오 가이드의 id", required = true,
-      dataType = "Long", paramType = "path", defaultValue = "9"
+      dataType = "Long", paramType = "path", defaultValue = "1"
   )
   @ApiResponses({
       @ApiResponse(code = 200, message = "OK"),
       @ApiResponse(code = 500, message = "Internal Server Error"),
       @ApiResponse(code = 404, message = "No corresponding Audio guide Data in DB")
   })
-  @GetMapping("/audio-guides/{audio-guide-id:^[0-9]+$}/directions")
+  @GetMapping("/v1/audio-guides/{audio-guide-id:^[0-9]+$}/directions")
   public ResponseEntity<ResAudioGuideDirectionsDto> getAudioGuideDirections(
       @PathVariable(value = "audio-guide-id") Long audioGuideId) {
     return ResponseEntity.status(HttpStatus.OK)
         .body(audioGuideService.getAudioGuideDirections(audioGuideId));
   }
+
+  /*
 
   @ApiOperation(value = "사용자 위치(위도,경도) 기반 반경 내 오디오 트랙의 정보",
       notes = "사용자의 위도,경도를 기준으로 반경 50m 이내에 존재하는 트랙의 정보를 제공합니다.\n "

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideDirectionsDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioGuideDirectionsDto.java
@@ -7,18 +7,22 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@JsonPropertyOrder({"audioGuideId", "directions"})
+@JsonPropertyOrder({"audioGuideId", "trackPoints", "directions"})
 public class ResAudioGuideDirectionsDto {
 
   @ApiModelProperty(notes = "오디오 가이드 id")
   private Long audioGuideId;
 
+  @ApiModelProperty(notes = "가이드의 각 트랙 point 들의 위도경도 리스트")
+  private List<ResTrackPointDto> trackPoints;
+
   @ApiModelProperty(notes = "direction 폴리라인의 위도경도 정보 리스트")
   private List<ResDirectionDto> directions;
 
   @Builder
-  private ResAudioGuideDirectionsDto(Long audioGuideId, List<ResDirectionDto> directions) {
+  private ResAudioGuideDirectionsDto(Long audioGuideId, List<ResTrackPointDto> trackPoints, List<ResDirectionDto> directions) {
     this.audioGuideId = audioGuideId;
+    this.trackPoints = trackPoints;
     this.directions = directions;
   }
 }

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResAudioTrackInfoItemDto.java
@@ -29,23 +29,15 @@ public class ResAudioTrackInfoItemDto {
   @ApiModelProperty(notes = "오디오 트랙 이미지")
   private List<String> images;
 
-  @ApiModelProperty(notes = "오디오 트랙의 위도")
-  private Double trackLatitude;
-
-  @ApiModelProperty(notes = "오디오 트랙의 경도")
-  private Double trackLongitude;
-
   @Builder
   private ResAudioTrackInfoItemDto(Long audioTrackId, String title, String runningTime,
       List<String> images, String audioFileUrl,
-      Integer orderNumber, Double trackLatitude, Double trackLongitude) {
+      Integer orderNumber) {
     this.audioTrackId = audioTrackId;
     this.title = title;
     this.runningTime = runningTime;
     this.images = images;
     this.audioFileUrl = audioFileUrl;
     this.trackOrderNumber = orderNumber;
-    this.trackLatitude = trackLatitude;
-    this.trackLongitude = trackLongitude;
   }
 }

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResTrackPointDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/dto/response/ResTrackPointDto.java
@@ -1,0 +1,19 @@
+package team_mic.here_and_there.backend.audio_guide.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonPropertyOrder({"trackOrder", "trackId", "trackLatitude", "trackLongitude"})
+public class ResTrackPointDto {
+
+  private Integer trackOrder;
+
+  private Long trackId;
+
+  private Double trackLatitude;
+
+  private Double trackLongitude;
+}

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioGuideService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioGuideService.java
@@ -22,6 +22,7 @@ import team_mic.here_and_there.backend.audio_guide.dto.response.ResAudioTrackInf
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResDirectionDto;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResPatchedSingleAudioGuideDto;
 import team_mic.here_and_there.backend.audio_guide.dto.response.ResSingleAudioGuideDetailDto;
+import team_mic.here_and_there.backend.audio_guide.dto.response.ResTrackPointDto;
 import team_mic.here_and_there.backend.audio_guide.exception.NoCorrespondingAudioGuideException;
 import team_mic.here_and_there.backend.common.domain.Language;
 import team_mic.here_and_there.backend.location_tag.domain.entity.AudioGuideTag;
@@ -138,19 +139,29 @@ public class AudioGuideService {
     return audioGuideRepository.findById(audioGuideId)
         .orElseThrow(() -> new NoCorrespondingAudioGuideException());
   }
-  /*
+
   public ResAudioGuideDirectionsDto getAudioGuideDirections(Long audioGuideId) {
     AudioGuide audioGuide = findAudioGuideById(audioGuideId);
     Set<AudioGuideTrackContainer> tracks = audioGuide.getTracks();
+
+    List<ResTrackPointDto> trackPointList = tracks.parallelStream()
+            .map(audioGuideTrackContainer -> ResTrackPointDto.builder()
+            .trackId(audioGuideTrackContainer.getAudioTrack().getId())
+            .trackOrder(audioGuideTrackContainer.getOrderNumber())
+            .trackLatitude(audioGuideTrackContainer.getAudioTrack().getLocationLatitude())
+            .trackLongitude(audioGuideTrackContainer.getAudioTrack().getLocationLongitude())
+            .build())
+        .collect(Collectors.toList());
 
     List<ResDirectionDto> directionsList = directionApiService
         .getTracksPedestrianDirections(tracks);
 
     return ResAudioGuideDirectionsDto.builder()
         .audioGuideId(audioGuideId)
+        .trackPoints(trackPointList)
         .directions(directionsList)
         .build();
-  }*/
+  }
 
   public ResAudioGuideCategoryListDto getAudioGuideCategoryList(String category, String language) {
 

--- a/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
+++ b/src/main/java/team_mic/here_and_there/backend/audio_guide/service/AudioTrackService.java
@@ -54,8 +54,6 @@ public class AudioTrackService {
     return ResAudioTrackInfoItemDto.builder()
         .audioTrackId(track.getId())
         .orderNumber(audioGuideTrackContainer.getOrderNumber())
-        .trackLongitude(track.getLocationLongitude())
-        .trackLatitude(track.getLocationLatitude())
         .images(track.getImages())
         .title(correspondingContent.getTitle())
         .audioFileUrl(correspondingContent.getAudioFileUrl())


### PR DESCRIPTION
- 기존 상세 오디오 가이드 API 에 각 트랙의 위,경도 데이터를 제공해주지 않는 것으로 수정
- 기존 폴리라인 API 재활용 + 트랙 point  별 위경도 정보 제공
- Close # 50