### PR TITLE
[Feat] 관광지 상세정보 api html parsing 및 예외처리

### DIFF
--- a/src/main/java/team_mic/here_and_there/backend/attraction/controller/AttractionController.java
+++ b/src/main/java/team_mic/here_and_there/backend/attraction/controller/AttractionController.java
@@ -77,7 +77,7 @@ public class AttractionController {
       notes = "* content-id, content-type-id 에 해당하는 관광지의 상세 페이지를 조회합니다.\n"
           +"* 제공되는 정보\n"
           + "1. detailCommonInfo : 모든 관광지들이 공통적으로 가지고 있는 기본 정보\n"
-          + "2. detailIntroductionInfo : content-type-id 에 따라서 개별적으로 tour api 에서 제공하는 정보.(content-type-id 에 따라 필드가 달라집니다. 제공되는 필드 정보는 https://github.com/team-mic/HearAndThere_Server/issues/58 에서 확인 가능합니다.)"
+          + "2. detailIntroductionInfo : content-type-id 에 따라서 개별적으로 tour api 에서 제공하는 정보.(content-type-id 에 따라 필드가 달라집니다. 제공되는 필드 정보는 https://github.com/team-mic/HearAndThere_Server/issues/58 에서 확인 가능합니다.)\n"
           + "3. imagesList : tour api 에서 제공하는 관광지 이미지 + 기획상 추가된 관광지 이미지\n"
           + "4. hasRelatedAudioGuides : 관광지와 연결된 추천 오디오 가이드의 존재여부\n"
           + "5. relatedAudioGuidesCount : 관광지와 연결된 추천 오디오 가이드 개수\n"

--- a/src/main/java/team_mic/here_and_there/backend/attraction/dto/response/ResAttractionDetailCommonDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/attraction/dto/response/ResAttractionDetailCommonDto.java
@@ -1,15 +1,19 @@
 package team_mic.here_and_there.backend.attraction.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -26,6 +30,8 @@ public class ResAttractionDetailCommonDto {
   @JsonProperty("title")
   private String title;
 
+  private String image;
+
   private String address;
 
   @JsonProperty("zipcode")
@@ -37,6 +43,16 @@ public class ResAttractionDetailCommonDto {
 
   @JsonProperty("overview")
   private String overview;
+
+  @JsonIgnore //not show this field in response
+  public String getImage() {
+    return this.image;
+  }
+
+  @JsonSetter("firstimage")
+  public void setImage(String image) {
+    this.image = image;
+  }
 
   @JsonSetter("addr1")
   private void setAddress(String address){


### PR DESCRIPTION
- tour api 에서 제공되는 데이터 중에 html 태그가 붙어있는 경우 plain text로 parsing 처리
- null 값에 대한 예외처리
- common 상세정보의 firstimage도 imageList에 추가해서 제공
- #57