### PR TITLE
[Fix] 인기검색어 API 배포 초기용 더미 데이터 제공 로직 작성

### DIFF
--- a/src/main/java/team_mic/here_and_there/backend/search/controller/SearchController.java
+++ b/src/main/java/team_mic/here_and_there/backend/search/controller/SearchController.java
@@ -93,14 +93,14 @@ public class SearchController {
   })
   @GetMapping("/v1/search-keywords/rankings/popular")
   public ResponseEntity<ResSearchKeywordRankListDto> getPopularSearchKeywordsRankings(
-      @ApiParam(value = "언어버전", required = true, example = "kor")
-      @RequestParam(value = "lan") String language,
+      @ApiParam(value = "언어버전", defaultValue = "kor", example = "kor", required = true, allowableValues = "kor,eng")
+      @RequestParam(value = "lan") Language language,
       @ApiParam(value = "순위 개수", defaultValue = "10", example = "10")
       @RequestParam(value = "count", required = false, defaultValue = "10") Integer count,
       @ApiParam(value = "더미데이터 요청", example = "true")
       @RequestParam(value = "dummy", required = false) Boolean withDummyData
       ) {
-    if (!language.equals(Language.KOREAN.getVersion()) && !language.equals(Language.ENGLISH.getVersion())) {
+    if (!language.equals(Language.KOREAN) && !language.equals(Language.ENGLISH)) {
       throw new HttpClientErrorException(HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/team_mic/here_and_there/backend/search/dto/response/ResSearchKeywordRankListDto.java
+++ b/src/main/java/team_mic/here_and_there/backend/search/dto/response/ResSearchKeywordRankListDto.java
@@ -14,5 +14,9 @@ public class ResSearchKeywordRankListDto {
   private String language;
   @ApiModelProperty(notes = "순위 결과 개수")
   private Integer count;
+
+  @ApiModelProperty(notes = "더미 데이터 여부")
+  private Boolean isDummyData;
+
   private List<ResSearchKeywordItemDto> keywordRankList;
 }

--- a/src/main/java/team_mic/here_and_there/backend/search/service/SearchDataService.java
+++ b/src/main/java/team_mic/here_and_there/backend/search/service/SearchDataService.java
@@ -20,23 +20,36 @@ public class SearchDataService {
   private final AudioGuideLanguageContentRepository audioGuideLanguageContentRepository;
   private final TripTipRepository tripTipRepository;
 
-  public ResSearchKeywordRankListDto getPopularSearchKeywordsRankingsWithDummyData(String language, Integer count) {
-    Language lan = null;
+  public ResSearchKeywordRankListDto getPopularSearchKeywordsRankingsWithDummyData(Language language, Integer count) {
     List<List<Object>> dummyAttractions = new ArrayList<>();
 
-    if(language.equals(Language.ENGLISH.getVersion())){
-      lan = Language.ENGLISH;
-      dummyAttractions.add(new ArrayList<Object>(){{add("Gyeongbokgung Palace (경복궁)"); add(76); add(264337L);}});
-      dummyAttractions.add(new ArrayList<Object>(){{add("Lotte World (롯데월드)"); add(76); add(264152L);}});
+    if(language.equals(Language.ENGLISH)){
+      dummyAttractions.add(new ArrayList<>() {{
+        add("Gyeongbokgung Palace (경복궁)");
+        add(76);
+        add(264337L);
+      }});
+      dummyAttractions.add(new ArrayList<>() {{
+        add("Lotte World (롯데월드)");
+        add(76);
+        add(264152L);
+      }});
     }
-    if(language.equals(Language.KOREAN.getVersion())){
-      lan = Language.KOREAN;
-      dummyAttractions.add(new ArrayList<Object>(){{add("홍릉수목원"); add(12); add(126500L);}});
-      dummyAttractions.add(new ArrayList<Object>(){{add("청계산"); add(12); add(125452L);}});
+    if(language.equals(Language.KOREAN)){
+      dummyAttractions.add(new ArrayList<>() {{
+        add("홍릉수목원");
+        add(12);
+        add(126500L);
+      }});
+      dummyAttractions.add(new ArrayList<>() {{
+        add("청계산");
+        add(12);
+        add(125452L);
+      }});
     }
 
-    List<AudioGuideLanguageContent> dummyGuideContents = audioGuideLanguageContentRepository.findAllByLanguage(lan).subList(0,4);
-    List<TripTip> dummyTripTips = tripTipRepository.findAllByLanguage(lan).subList(0,4);
+    List<AudioGuideLanguageContent> dummyGuideContents = audioGuideLanguageContentRepository.findAllByLanguage(language).subList(0,4);
+    List<TripTip> dummyTripTips = tripTipRepository.findAllByLanguage(language).subList(0,4);
 
     Integer maxDummySearchKeywordsCount = 10;
 
@@ -49,7 +62,9 @@ public class SearchDataService {
     searchKeywordItemList.addAll(dummyGuideContents.stream()
         .map(guideContent -> ResSearchKeywordItemDto.builder()
             .keywordType("audio-guide")
-            .keywordTargetIds(new ArrayList<Long>(){{add(guideContent.getAudioGuide().getId());}})
+            .keywordTargetIds(new ArrayList<>() {{
+              add(guideContent.getAudioGuide().getId());
+            }})
             .searchHitCounts(30L)
             .keywordTitle(guideContent.getTitle())
         .build())
@@ -60,7 +75,9 @@ public class SearchDataService {
       .map(tripTip -> ResSearchKeywordItemDto.builder()
           .keywordType("trip-tip")
           .keywordTitle(tripTip.getTitle())
-          .keywordTargetIds(new ArrayList<Long>(){{add(tripTip.getId());}})
+          .keywordTargetIds(new ArrayList<>() {{
+            add(tripTip.getId());
+          }})
           .tripTipContentsUrl(tripTip.getContentsUrl())
           .searchHitCounts(20L)
         .build())
@@ -71,14 +88,18 @@ public class SearchDataService {
         .map(attraction -> ResSearchKeywordItemDto.builder()
             .keywordType("attraction")
             .keywordTitle((String) attraction.get(0))
-            .keywordTargetIds(new ArrayList<Long>(){{add(Long.valueOf((Integer)attraction.get(1))); add((Long) attraction.get(2));}})
+            .keywordTargetIds(new ArrayList<>(){{
+              add(Long.valueOf((Integer)attraction.get(1)));
+              add((Long) attraction.get(2));
+            }})
             .searchHitCounts(10L)
             .build())
         .collect(Collectors.toList()));
 
     return ResSearchKeywordRankListDto.builder()
         .count(count)
-        .language(lan.getVersion())
+        .isDummyData(true)
+        .language(language.getVersion())
         .keywordRankList(searchKeywordItemList.subList(0, count))
         .build();
   }

--- a/src/test/java/team_mic/here_and_there/backend/search/service/SearchKeywordServiceTest.java
+++ b/src/test/java/team_mic/here_and_there/backend/search/service/SearchKeywordServiceTest.java
@@ -1,0 +1,106 @@
+package team_mic.here_and_there.backend.search.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import javax.persistence.Index;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import team_mic.here_and_there.backend.common.domain.Language;
+import team_mic.here_and_there.backend.search.domain.entity.SearchAttraction;
+import team_mic.here_and_there.backend.search.domain.entity.SearchAudioGuide;
+import team_mic.here_and_there.backend.search.domain.entity.SearchKeyword;
+import team_mic.here_and_there.backend.search.domain.repository.SearchKeywordRepository;
+import team_mic.here_and_there.backend.search.dto.response.ResSearchKeywordRankListDto;
+
+@ExtendWith(MockitoExtension.class)
+public class SearchKeywordServiceTest {
+
+  @Mock
+  private SearchKeywordRepository searchKeywordRepository;
+
+  @InjectMocks
+  private SearchService searchService;
+
+  @Mock
+  private SearchDataService searchDataService;
+
+  @Test
+  public void 배포_초기_데이터가_countParam_미만일경우_더미데이터제공_테스트(){
+    //given
+    Language givenLanguage = Language.KOREAN;
+    Integer givenCountParam = 10;
+
+    given(searchKeywordRepository.getTotalCountsByLanguage(givenLanguage))
+        .willReturn(2L);
+
+    //when
+    ResSearchKeywordRankListDto rankListDto = searchService.getPopularSearchKeywordsRankings(givenLanguage, givenCountParam);
+
+    //then
+    then(searchKeywordRepository)
+        .should(never())
+        .findAllByLanguage(any(Language.class), any(PageRequest.class));
+
+    then(searchDataService)
+        .should()
+        .getPopularSearchKeywordsRankingsWithDummyData(givenLanguage, givenCountParam);
+  }
+
+  @Test
+  public void 데이터가_countParam_이상일경우_실제데이터제공_테스트(){
+    //given
+    Language givenLanguage = Language.KOREAN;
+    Integer givenCountParam = 2;
+    PageRequest givenPageRequest = PageRequest.of(0, givenCountParam, Sort.by("searchHitCounts").descending().and(Sort.by("id").ascending()));
+
+    given(searchKeywordRepository.getTotalCountsByLanguage(givenLanguage))
+        .willReturn(2L);
+
+    given(searchKeywordRepository.findAllByLanguage(givenLanguage, givenPageRequest))
+        .willReturn(List.of(
+            SearchAttraction.builder()
+                    .language(givenLanguage)
+                    .contentId(1L)
+                    .contentTypeId(1)
+                    .title("test1").build(),
+            SearchAttraction.builder()
+                .language(givenLanguage)
+                .contentId(1L)
+                .contentTypeId(2)
+                .title("test2").build()));
+
+    //when
+    ResSearchKeywordRankListDto rankListDto = searchService.getPopularSearchKeywordsRankings(givenLanguage, givenCountParam);
+
+    //then
+    then(searchDataService)
+        .should(never())
+        .getPopularSearchKeywordsRankingsWithDummyData(givenLanguage, givenCountParam);
+
+    then(searchKeywordRepository)
+        .should()
+        .findAllByLanguage(givenLanguage, givenPageRequest);
+
+    assertEquals(false, rankListDto.getIsDummyData());
+    assertEquals(2, rankListDto.getCount());
+  }
+}


### PR DESCRIPTION
- SearchKeyword 총 데이터 개수가 count param 미만이면 임의의 초기용 더미 데이터 제공
- SearchKeyword 총 데이터 개수가 count param 이상이면 hit-count 기반 데이터 제공
- 테스트코드 작성